### PR TITLE
feature/#4: 공고 등록 기능 추가+.env.example+SecurityConfig분리

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+//http://localhost:8080/oauth2/authorization/google
+//위 url로 접속

--- a/src/main/java/com/chaineeproject/chainee/config/SecurityConfigDev.java
+++ b/src/main/java/com/chaineeproject/chainee/config/SecurityConfigDev.java
@@ -1,37 +1,41 @@
 package com.chaineeproject.chainee.config;
 
-import com.chaineeproject.chainee.service.CustomOauth2UserService;
 import com.chaineeproject.chainee.security.handler.CustomOAuth2FailureHandler;
+import com.chaineeproject.chainee.service.CustomOauth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
+@Profile("dev")
 @RequiredArgsConstructor
-public class SecurityConfig {
+public class SecurityConfigDev {
 
     private final CustomOauth2UserService customOauth2UserService;
     private final CustomOAuth2FailureHandler customOAuth2FailureHandler;
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain devSecurityFilterChain(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/h2-console/**").permitAll()
                         .requestMatchers("/", "/login", "/css/**", "/js/**").permitAll()
+                        .requestMatchers("/h2-console/**").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/job/posts/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth -> oauth
                         .loginPage("/login")
                         .userInfoEndpoint(userInfo -> userInfo
-                                .userService(customOauth2UserService)
-                        )
-                        .failureHandler(customOAuth2FailureHandler) // 추가: OAuth 로그인 실패 처리
+                                .userService(customOauth2UserService))
+                        .failureHandler(customOAuth2FailureHandler)
                 )
                 .csrf(csrf -> csrf.disable())
-                .headers(headers -> headers.frameOptions().disable());
+                .headers(headers -> headers.frameOptions(frame -> frame.disable()));
+
 
         return http.build();
     }

--- a/src/main/java/com/chaineeproject/chainee/config/SecurityConfigProd.java
+++ b/src/main/java/com/chaineeproject/chainee/config/SecurityConfigProd.java
@@ -1,0 +1,37 @@
+package com.chaineeproject.chainee.config;
+
+import com.chaineeproject.chainee.security.handler.CustomOAuth2FailureHandler;
+import com.chaineeproject.chainee.service.CustomOauth2UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@Profile("prod")
+@RequiredArgsConstructor
+public class SecurityConfigProd {
+
+    private final CustomOauth2UserService customOauth2UserService;
+    private final CustomOAuth2FailureHandler customOAuth2FailureHandler;
+
+    @Bean
+    public SecurityFilterChain prodSecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/", "/login", "/css/**", "/js/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .oauth2Login(oauth -> oauth
+                        .loginPage("/login")
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(customOauth2UserService))
+                        .failureHandler(customOAuth2FailureHandler)
+                )
+                .csrf(csrf -> csrf.disable());
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/chaineeproject/chainee/controller/JobPostController.java
+++ b/src/main/java/com/chaineeproject/chainee/controller/JobPostController.java
@@ -1,0 +1,75 @@
+package com.chaineeproject.chainee.controller;
+
+import com.chaineeproject.chainee.dto.JobPostRequest;
+import com.chaineeproject.chainee.dto.JobPostResponse;
+import com.chaineeproject.chainee.entity.JobPost;
+import com.chaineeproject.chainee.entity.User;
+import com.chaineeproject.chainee.repository.JobPostRepository;
+import com.chaineeproject.chainee.repository.UserRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+
+@RestController
+@RequestMapping("/api/job/posts")
+@RequiredArgsConstructor
+@Slf4j
+public class JobPostController {
+
+    private final UserRepository userRepository;
+    private final JobPostRepository jobPostRepository;
+    private final ObjectMapper objectMapper;
+
+    @PostMapping
+    public ResponseEntity<JobPostResponse> createJobPost(@RequestBody JobPostRequest request) {
+        try {
+            // 1. 작성자 DID로 유저 조회
+            User author = userRepository.findByDid(request.getAuthorDid())
+                    .orElseThrow(() -> new IllegalArgumentException("작성자(DID)를 찾을 수 없습니다."));
+
+            // 2. requiredSkills → JSON 문자열로 변환
+            String skillsJson = objectMapper.writeValueAsString(request.getRequiredSkills());
+
+            // 3. 엔티티 생성 및 저장
+            JobPost post = JobPost.builder()
+                    .author(author)
+                    .title(request.getTitle())
+                    .description(request.getDescription())
+                    .payment(request.getPayment())
+                    .requiredSkills(skillsJson)
+                    .duration(request.getDuration())
+                    .deadline(request.getDeadline())
+                    .createdAt(LocalDateTime.now())
+                    .build();
+
+            jobPostRepository.save(post);
+
+            // 4. 응답 반환
+            return ResponseEntity.ok(new JobPostResponse(
+                    true,
+                    "JOB_POST_CREATED",
+                    new JobPostResponse.DataWrapper("post-" + post.getId())
+            ));
+
+        } catch (JsonProcessingException e) {
+            log.error("requiredSkills 변환 실패", e);
+            return ResponseEntity.internalServerError().body(new JobPostResponse(
+                    false,
+                    "SKILL_PARSE_ERROR",
+                    null
+            ));
+        } catch (Exception e) {
+            log.error("구인 공고 등록 실패", e);
+            return ResponseEntity.internalServerError().body(new JobPostResponse(
+                    false,
+                    "JOB_POST_CREATION_FAILED",
+                    null
+            ));
+        }
+    }
+}

--- a/src/main/java/com/chaineeproject/chainee/dto/JobPostRequest.java
+++ b/src/main/java/com/chaineeproject/chainee/dto/JobPostRequest.java
@@ -1,0 +1,19 @@
+package com.chaineeproject.chainee.dto;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+public class JobPostRequest {
+
+    private String authorDid;
+    private String title;
+    private String description;
+    private BigDecimal payment;
+    private List<String> requiredSkills;
+    private String duration;  // "6m", "1y"
+    private LocalDate deadline;
+}

--- a/src/main/java/com/chaineeproject/chainee/dto/JobPostResponse.java
+++ b/src/main/java/com/chaineeproject/chainee/dto/JobPostResponse.java
@@ -1,0 +1,18 @@
+package com.chaineeproject.chainee.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class JobPostResponse {
+    private boolean success;
+    private String messageCode;
+    private DataWrapper data;
+
+    @Data
+    @AllArgsConstructor
+    public static class DataWrapper {
+        private String postId;
+    }
+}

--- a/src/main/java/com/chaineeproject/chainee/entity/JobPost.java
+++ b/src/main/java/com/chaineeproject/chainee/entity/JobPost.java
@@ -1,6 +1,7 @@
 package com.chaineeproject.chainee.entity;
 
 import jakarta.persistence.*;
+import lombok.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -8,7 +9,13 @@ import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "job_post")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class JobPost {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -25,7 +32,10 @@ public class JobPost {
     private BigDecimal payment;
 
     @Lob
-    private String requiredSkills;
+    @Column(name = "required_skills")
+    private String requiredSkills; // JSON 문자열로 저장
+
+    private String duration; // "6m", "1y" 등
 
     private LocalDate deadline;
 

--- a/src/main/java/com/chaineeproject/chainee/repository/JobPostRepository.java
+++ b/src/main/java/com/chaineeproject/chainee/repository/JobPostRepository.java
@@ -1,0 +1,8 @@
+package com.chaineeproject.chainee.repository;
+
+import com.chaineeproject.chainee.entity.JobPost;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JobPostRepository extends JpaRepository<JobPost, Long> {
+    // 추후 postId로 검색 등 추가 가능
+}

--- a/src/main/java/com/chaineeproject/chainee/repository/UserRepository.java
+++ b/src/main/java/com/chaineeproject/chainee/repository/UserRepository.java
@@ -9,4 +9,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
     boolean existsByEmail(String email);
+
+    Optional<User> findByDid(String did);
 }


### PR DESCRIPTION
## 🔀 PR 제목  
공고 등록 기능 추가 + `.env.example` 추가 + SecurityConfig 환경 분리

---

## 📌 주요 변경 사항

### 1. ✨ 공고 등록 기능 구현
- `JobPost` 엔티티에 `duration` 필드 추가 (`6m`, `1y` 등 계약 기간)
- 공고 등록 API 구현:  
  - `POST /api/job/posts`
  - 요청 데이터: 작성자 DID, 제목, 설명, 급여, 기술스택, 마감일, 계약기간 등
- `JobPostService`, `JobPostRepository` 추가
- `UserRepository`에 `findByDid()` 메서드 추가

---

### 2. ⚙ `.env.example` 추가
- 민감한 환경 변수 관리용 `.env.example` 템플릿 파일 생성
- 실제 `.env`는 `.gitignore`에 포함되어 Git에 올라가지 않도록 설정

---

### 3. 🔐 SecurityConfig 환경 분리
- `@Profile("dev")` → `SecurityConfigDev.java`:  
  - H2 콘솔 및 일부 API 접근 허용
  - 프레임 옵션 및 CSRF 비활성화
- `@Profile("prod")` → `SecurityConfigProd.java`:  
  - 모든 요청 인증 필요
  - 보안 강화 설정 적용

---

## ✅ 기타
- 테스트용 사용자 등록을 위한 H2 insert 쿼리 및 Postman 테스트 완료
- 불필요한 deprecated API (`disableFrameOptions`) 제거
